### PR TITLE
Fix typo provoking error on molecule weight variable

### DIFF
--- a/spectral/species.py
+++ b/spectral/species.py
@@ -381,7 +381,7 @@ def getChemicalInformationsFromInchi(inchi):
         total_charge (integer): the total electric charge of the species
         atom_set (set): a set containing unique atoms forming a given species.
         atom_list (list): a list containing the atoms forming a given species (with eventual duplications) 
-        molWeight (integer) : the molecular mass of the species. 
+        mol_weight (integer) : the molecular mass of the species.
     """
     mol = Chem.MolFromInchi(inchi, sanitize=False, removeHs=False)
     mol = Chem.AddHs(mol) 
@@ -395,9 +395,9 @@ def getChemicalInformationsFromInchi(inchi):
         atoms_list.append(atom.GetSymbol())
         total_charge += atom.GetFormalCharge()
 
-    molWeight = Descriptors.ExactMolWt(mol)
+    mol_weight = Descriptors.ExactMolWt(mol)
 
-    return len(atoms_set), len(atoms_list), total_charge, atoms_set, atoms_list, molWeight
+    return len(atoms_set), len(atoms_list), total_charge, atoms_set, atoms_list, mol_weight
 
 
 
@@ -422,7 +422,7 @@ def addComputedChemicalInfo(input_df):
             inchi = row['InChI']
             try:
                 # get some chemical information locally, from the InChI
-                number_unique_atoms, number_total_atoms, computed_charge, _, _, computedWeight = getChemicalInformationsFromInchi(inchi)
+                number_unique_atoms, number_total_atoms, computed_charge, _, _, computed_weight = getChemicalInformationsFromInchi(inchi)
             except:
                 # if the chemical information can not be deduced from the Inchi
                 print("Exception in converting the InChI:" + str(inchi))
@@ -435,7 +435,7 @@ def addComputedChemicalInfo(input_df):
                 input_df.at[index, '# unique atoms'] = number_unique_atoms
                 input_df.at[index, '# total atoms'] = number_total_atoms
                 input_df.at[index, 'computed charge'] =  computed_charge
-                input_df.at[index, 'computed mol_weight'] =  computedWeight
+                input_df.at[index, 'computed mol_weight'] =  computed_weight
                 
     # return the enriched dataframe
     return input_df


### PR DESCRIPTION
There are a typo provoking an error with molecule weight variable  with the code
species_df , _ = species.getSpeciesWithSearchCriteria(mass_max=40, type="molecule")
-> UnboundLocalError: local variable 'computedWeight' referenced before assignment

this commit fix this bug