### PR TITLE
Enable using uvx --from git+https://github.com/VAMDC/pyVAMDC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,12 @@ Repository = "https://github.com/VAMDC/pyVAMDC.git"
 Issues = "https://github.com/VAMDC/pyVAMDC/issues"
 
 [tool.setuptools]
-packages = ["pyVAMDC", "pyVAMDC.spectral"]
+packages = ["pyVAMDC", "pyVAMDC.spectral", "pyVAMDC.radex"]
 
 [tool.setuptools.package-dir]
 "pyVAMDC" = "."
 "pyVAMDC.spectral" = "spectral"
+"pyVAMDC.radex" = "radex"
 
 [tool.setuptools.package-data]
 "*" = ["xsl/*.xsl"]

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,25 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
-    name='pyVAMDC',
-    version='0.1',
-    description='A brand-new library to interact with the VAMDC infrastructure',
-    author='Carlo Maria Zwölf, Nicolas Moreau',
-    packages=["pyVAMDC", "pyVAMDC.spectral"],
+    name="pyVAMDC",
+    version="0.1",
+    description="A brand-new library to interact with the VAMDC infrastructure",
+    author="Carlo Maria Zwölf, Nicolas Moreau",
+    packages=["pyVAMDC", "pyVAMDC.spectral", "pyVAMDC.radex"],
     package_dir={
-    'pyVAMDC': '.',
-    'pyVAMDC.spectral': './spectral',
+        "pyVAMDC": ".",
+        "pyVAMDC.spectral": "./spectral",
+        "pyVAMDC.radex": "./radex",
     },
-    package_data={'':['./xsl/*.xsl']},
+    package_data={"": ["./xsl/*.xsl"]},
     include_package_data=True,
-    install_requires=['pandas','lxml', 'numpy>=2.0.0', 'requests','rdkit', 'duckdb>=0.9.0', 'pyarrow>=10.0.0'] 
+    install_requires=[
+        "pandas",
+        "lxml",
+        "numpy>=2.0.0",
+        "requests",
+        "rdkit",
+        "duckdb>=0.9.0",
+        "pyarrow>=10.0.0",
+    ],
 )


### PR DESCRIPTION
When calling the tool directly from the repository without cloning beforehand using
```uvx --from git+https://github.com/VAMDC/pyVAMDC vamdc --help```


the following error is raised:
```
Traceback (most recent call last):
  File "/Users/pierregratier/.cache/uv/archive-v0/ABNdlmstxgu5SE_X/lib/python3.14/site-packages/pyVAMDC/spectral/cli.py", line 17, in <module>
    from spectral import species as species_module
ModuleNotFoundError: No module named 'spectral'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pierregratier/.cache/uv/archive-v0/ABNdlmstxgu5SE_X/bin/vamdc", line 6, in <module>
    from pyVAMDC.spectral.cli import cli
  File "/Users/pierregratier/.cache/uv/archive-v0/ABNdlmstxgu5SE_X/lib/python3.14/site-packages/pyVAMDC/spectral/cli.py", line 32, in <module>
    from pyVAMDC.radex.radex import getRadex as radex_getRadex
ModuleNotFoundError: No module named 'pyVAMDC.radex'
```

This PR proposes a solution by modifying the pyproject.toml and setup.py to expose the pyVAMDC.radex and pyVAMDC.spectral packages

Test of the solution:
```uvx --from git+https://github.com/pierregratier/pyVAMDC@pg/uv_git vamdc --help```